### PR TITLE
Preparing for release 1.0.0-alpha02

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,7 +69,7 @@ winds {
     url = "https://source.teogor.dev/querent"
 
     version = createVersion(1, 0, 0) {
-      alphaRelease(1)
+      alphaRelease(2)
     }
 
     project.group = winds.mavenPublish.groupId ?: "undefined"
@@ -97,6 +97,9 @@ winds {
 }
 
 afterWindsPluginConfiguration { winds ->
+  project.group = winds.mavenPublish.groupId ?: "undefined"
+  project.version = winds.mavenPublish.version ?: "undefined"
+
   if (!plugins.hasPlugin("com.gradle.plugin-publish")) {
     val mavenPublish: MavenPublish by winds
     if (mavenPublish.canBePublished) {

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -18,6 +18,7 @@ sizes and difficulty levels.
 
 |   Latest Update   | Stable Release | Beta Release | Alpha Release |
 |:-----------------:|:--------------:|:------------:|:-------------:|
+| February 23, 2023 |       -        |      -       | 1.0.0-alpha02 |
 | November 27, 2023 |       -        |      -       | 1.0.0-alpha01 |
 
 ### Declaring dependencies
@@ -31,7 +32,7 @@ Add the dependencies for the artifacts you need in the `build.gradle` file for y
 
     ```kotlin
     plugins {
-      id("dev.teogor.querent") version "1.0.0-alpha01"
+      id("dev.teogor.querent") version "1.0.0-alpha02"
     }
 
     repositories {
@@ -39,7 +40,7 @@ Add the dependencies for the artifacts you need in the `build.gradle` file for y
     }
 
     dependencies {
-      implementation("dev.teogor.querent:gradle-plugin-api:1.0.0-alpha01")
+      implementation("dev.teogor.querent:gradle-plugin-api:1.0.0-alpha02")
     }
     ```
 
@@ -47,7 +48,7 @@ Add the dependencies for the artifacts you need in the `build.gradle` file for y
 
     ```groovy
     plugins {
-      id 'dev.teogor.querent' version '1.0.0-alpha01'
+      id 'dev.teogor.querent' version '1.0.0-alpha02'
     }
 
     repositories {
@@ -55,7 +56,7 @@ Add the dependencies for the artifacts you need in the `build.gradle` file for y
     }
 
     dependencies {
-      implementation 'dev.teogor.querent:gradle-plugin-api:1.0.0-alpha01'
+      implementation 'dev.teogor.querent:gradle-plugin-api:1.0.0-alpha02'
     }
     ```
 
@@ -70,6 +71,26 @@ existing issue by clicking the star button.
 [Create a new issue](https://github.com/teogor/querent/issues/new){ .md-button }
 
 ### Version 1.0.0
+
+#### Version 1.0.0-alpha02
+
+February 23, 2024
+
+`dev.teogor.querent:querent-*:1.0.0-alpha02` is
+released. [Version 1.0.0-alpha02 contains these commits.](https://github.com/teogor/querent/compare/1.0.0-alpha01...1.0.0-alpha02)
+
+**Bug Fixes**
+
+* Introduce dependency on generated compose resources task for preBuild
+  phase ([#11](https://github.com/teogor/querent/pull/11)) by [@teogor](https://github.com/teogor)
+* Introduce API level 26 requirements for `systemZoneOffset`
+  and `buildLocalDateTime` ([#9](https://github.com/teogor/querent/pull/9))
+  by [@teogor](https://github.com/teogor)
+
+**Others**
+
+* Migrate to Java 17 ([#6](https://github.com/teogor/querent/pull/6))
+  by [@teogor](https://github.com/teogor)
 
 #### Version 1.0.0-alpha01
 

--- a/docs/releases/changelog/1.0.0-alpha02.md
+++ b/docs/releases/changelog/1.0.0-alpha02.md
@@ -1,0 +1,10 @@
+[//]: # (This file was automatically generated - do not edit)
+
+# Version 1.0.0-alpha02
+
+## Latest SDK versions
+
+| Status |                               Service or Product                               |          Gradle dependency           | Latest version |
+|:------:|:------------------------------------------------------------------------------:|:------------------------------------:|:--------------:|
+|   🧪   |     [Querent Gradle Plugin](../../../html/gradle-plugin){:target="_blank"}     |          dev.teogor.querent          | 1.0.0-alpha02  |
+|   🧪   | [Querent Gradle Plugin API](../../../html/gradle-plugin-api){:target="_blank"} | dev.teogor.querent:gradle-plugin-api | 1.0.0-alpha02  |

--- a/docs/releases/implementation.md
+++ b/docs/releases/implementation.md
@@ -4,7 +4,7 @@
 
 ### Latest Version
 
-The latest release is [`1.0.0-alpha01`](../releases.md)
+The latest release is [`1.0.0-alpha02`](../releases.md)
 
 ### Releases
 
@@ -12,6 +12,7 @@ Here's a summary of the latest versions:
 
 |    Version    |               Release Notes                | Release Date |
 |:-------------:|:------------------------------------------:|:------------:|
+| 1.0.0-alpha02 | [changelog 🔗](changelog/1.0.0-alpha02.md) | 23 Feb 2024  |
 | 1.0.0-alpha01 | [changelog 🔗](changelog/1.0.0-alpha01.md) | 27 Nov 2023  |
 
 ### Using Version Catalog
@@ -25,7 +26,7 @@ libraries, in TOML format.
 
     ```toml title="gradle/libs.versions.toml"
     [versions]
-    teogor-querent = "1.0.0-alpha01"
+    teogor-querent = "1.0.0-alpha02"
 
     [libraries]
     teogor-querent-gradle-api = { module = "dev.teogor.querent:gradle-plugin-api", version.ref = "teogor-querent" }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
       - releases.md
       - Implementation: releases/implementation.md
       - Changelog:
+          - 1.0.0-alpha02: releases/changelog/1.0.0-alpha02.md
           - 1.0.0-alpha01: releases/changelog/1.0.0-alpha01.md
   - Reference: reference.md
   - Sponsor: sponsor.md


### PR DESCRIPTION
## Upgrade Querent to Version 1.0.0-alpha02

This pull request brings exciting news!  We're upgrading the Querent module to version 1.0.0-alpha02, unlocking new features and potential improvements.

**Changes:**

- Updated the Querent to `dev.teogor.querent:1.0.0-alpha02`.
- Tested the changes to ensure compatibility and smooth functionality.

**Benefits:**

- Access the latest capabilities and enhancements introduced in Querent 1.0.0-alpha02.
- Stay ahead of the curve and leverage potential performance improvements or bug fixes.